### PR TITLE
Fixed incorrect Staticman POST URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -115,4 +115,4 @@ summaryLength = "50"
 
 
 #[Params.staticman]
-#  api = "https://staticman-scirex/v3/entry/github/fahimscirex/fahimscirex.github.io/master/data/comments"
+#  api = "https://staticman-scirex.herokuapp.com/v3/entry/github/fahimscirex/fahimscirex.github.io/master/comments"


### PR DESCRIPTION
# Goal
To fix #1 
# Description
The following URL is a invalid.

    https://staticman-scirex/

Heroku apps usually have the domain name

    https://<app-name>.herokuapp.com

The property name in your POST URL is incorrect.  The property name should be `comments`.

# Analysis

The [beginning description of Staticman's site config file](https://github.com/eduardoboucas/staticman/blob/5d7ed7708775e3d4864382cca88d2d73ff875864/staticman.sample.yml#L1-L5) explains the concept of "property name" referred at [step 4 of the official quick start guide](https://staticman.net/docs/getting-started.html#step-4-hook-up-your-forms).  In practice, each line beginning with a non-space character in `staticman.yml` is treated as a property name.